### PR TITLE
Make sure that imports are properly scoped to directories that are requested from

### DIFF
--- a/tests/__snapshots__/index.test.ts.snap
+++ b/tests/__snapshots__/index.test.ts.snap
@@ -1,5 +1,43 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`test keeps proper scope of imports 1`] = `
+Object {
+  "default": Object {
+    "default": Array [
+      Object {
+        "default": "a",
+      },
+      Object {
+        "default": "b",
+      },
+    ],
+    "filenames": Array [
+      "./cases/a.js",
+      "./cases/b.js",
+    ],
+  },
+}
+`;
+
+exports[`test keeps proper scope of imports 2`] = `
+Object {
+  "default": Object {
+    "default": Array [
+      Object {
+        "default": "c",
+      },
+      Object {
+        "default": "d",
+      },
+    ],
+    "filenames": Array [
+      "./cases/c.js",
+      "./cases/d.js",
+    ],
+  },
+}
+`;
+
 exports[`test should 1`] = `
 Object {
   "default": Array [

--- a/tests/conflicts/conflictA/cases/a.js
+++ b/tests/conflicts/conflictA/cases/a.js
@@ -1,0 +1,1 @@
+export default 'a';

--- a/tests/conflicts/conflictA/cases/b.js
+++ b/tests/conflicts/conflictA/cases/b.js
@@ -1,0 +1,1 @@
+export default 'b';

--- a/tests/conflicts/conflictA/index.js
+++ b/tests/conflicts/conflictA/index.js
@@ -1,0 +1,2 @@
+// this is the same as in conflictB
+export * as default from './cases/*.js';

--- a/tests/conflicts/conflictB/cases/c.js
+++ b/tests/conflicts/conflictB/cases/c.js
@@ -1,0 +1,1 @@
+export default 'c';

--- a/tests/conflicts/conflictB/cases/d.js
+++ b/tests/conflicts/conflictB/cases/d.js
@@ -1,0 +1,1 @@
+export default 'd';

--- a/tests/conflicts/conflictB/index.js
+++ b/tests/conflicts/conflictB/index.js
@@ -1,0 +1,2 @@
+// this is the same as in conflictA
+export * as default from './cases/*.js';

--- a/tests/conflicts/main.ts
+++ b/tests/conflicts/main.ts
@@ -1,0 +1,5 @@
+// @ts-ignore
+import * as conflictingSetA from './conflictA';
+import * as conflictingSetB from './conflictB';
+
+console.log(conflictingSetA, conflictingSetB);


### PR DESCRIPTION
This PR fixes the case were there're same-sounding imports used in different paths. 

There's sample scenario in `conflicts` directory in tests. It contains 2 subdirectories with same-sounding index.js that imports all nested files (`export * as default from './cases/*.js';`), but they contain completely different set of files. 

Without the change, both the imports equals to contents of files from the later directory.